### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -17,8 +17,8 @@ read_byte	KEYWORD2
 write_byte	KEYWORD2
 read_page	KEYWORD2
 write_page	KEYWORD2
-read_stream KEYWORD2
-write_stream    KEYWORD2
+read_stream	KEYWORD2
+write_stream	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords